### PR TITLE
Add UCI method to enable uci mode in engine

### DIFF
--- a/uci.go
+++ b/uci.go
@@ -111,19 +111,19 @@ func (eng *Engine) UCI() error {
 func (eng *Engine) SetOptions(opt Options) error {
 	var err error
 	if opt.MultiPV > 0 {
-		err = eng.SendOption("multipv", opt.MultiPV)
+		err = eng.SendOption("MultiPV", opt.MultiPV)
 		if err != nil {
 			return err
 		}
 	}
 	if opt.Hash > 0 {
-		err = eng.SendOption("hash", opt.Hash)
+		err = eng.SendOption("Hash", opt.Hash)
 		if err != nil {
 			return err
 		}
 	}
 	if opt.Threads > 0 {
-		err = eng.SendOption("threads", opt.Threads)
+		err = eng.SendOption("Threads", opt.Threads)
 		if err != nil {
 			return err
 		}
@@ -286,7 +286,12 @@ func (res *Results) addLineToResults(line string) error {
 			}
 		case "time":
 			s.Scan()
-			r.Time, err = strconv.Atoi(s.TokenText())
+			token := s.TokenText()
+			if token == "-" {
+				s.Scan()
+				token = token + s.TokenText()
+			}
+			r.Time, err = strconv.Atoi(token)
 			if err != nil {
 				return err
 			}

--- a/uci.go
+++ b/uci.go
@@ -104,7 +104,6 @@ func (eng *Engine) UCI() error {
 	}
 	err = eng.stdin.Flush()
 	return err
-
 }
 
 // SetOptions sends setoption commands to the Engine

--- a/uci.go
+++ b/uci.go
@@ -96,6 +96,17 @@ func NewEngine(path string, arg ...string) (*Engine, error) {
 	return &eng, nil
 }
 
+// UCI sets the engine to uci mode
+func (eng *Engine) UCI() error {
+	_, err := eng.stdin.WriteString("uci\n")
+	if err != nil {
+		return err
+	}
+	err = eng.stdin.Flush()
+	return err
+
+}
+
 // SetOptions sends setoption commands to the Engine
 // for the values set in the Options record passed in
 func (eng *Engine) SetOptions(opt Options) error {


### PR DESCRIPTION
Some engines aren't in uci mode by default. For example the [Critter 1.6a engine](https://www.vlasak.biz/critter/), also HIARCS. Both engines do nothing until it receives `uci` and then they spring to life.

Also UCI option names are typically initial-uppercase (e.g. `Threads` instead of `threads`). Stockfish seems to be case insensitive, but other UCI engines, like Berserk 10, expect the initial-capitalisation of option names, and ignore all-lower-case.